### PR TITLE
Firefox notification option

### DIFF
--- a/src/firefox/background/background.js
+++ b/src/firefox/background/background.js
@@ -3,7 +3,7 @@ browser.runtime.onMessage.addListener(function(request, sender, sendResponse) {
         browser.pageAction.show(sender.tab.id)
         browser.pageAction.setIcon({ "tabId": sender.tab.id, "path": "assets/icon38.png" })
 
-        storage.sync.get('verbose', (obj) => {
+        browser.storage.sync.get('verbose', (obj) => {
             if (obj.hasOwnProperty('verbose')) {
                 if (obj.verbose) {
                     var string = "Fjernet " + request.objectsFound + " plussartikler fra " + request.url + "."

--- a/src/firefox/popup/popup.js
+++ b/src/firefox/popup/popup.js
@@ -1,7 +1,7 @@
 (function ($) {
 
     function saveVerboseOption (state) {
-        storage.sync.set({'verbose': state}, function () {
+        browser.storage.sync.set({'verbose': state}, function () {
             notifyChange("Lagret endringer.")
         })
     }
@@ -17,7 +17,7 @@
     $(document).ready(function () {
         var inputs = {'verbose': $('#verbose')}
 
-        storage.onChanged.addListener((changes, namespaces) => {
+        browser.storage.onChanged.addListener((changes, namespaces) => {
             for (var key in changes) {
                 var storageChange = changes[key]
                 for (var input in inputs) {
@@ -31,7 +31,7 @@
 
         for (var input in inputs) {
             var el = inputs[input]
-            storage.sync.get(input, (obj) => {
+            browser.storage.sync.get(input, (obj) => {
                 el.prop('checked', obj[input])
             })
         }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -6,6 +6,12 @@
     "author": "Nic",
 
     "version": "1.5.6",
+    "applications": {
+        "gecko": {
+            "id": "nichlas.torgersen@gmail.com"
+        }
+    },
+
 
     "icons": {
         "16": "assets/icon16.png",


### PR DESCRIPTION
Muligheten til å slå av notifications virker nå i Firefox også.

Måtte legge til eksplisitt Add-on ID for å kunne bruke storage.sync APIet. Som dokumentert [her](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/WebExtensions_and_the_Add-on_ID#When_do_you_need_an_Add-on_ID).

Satte IDen foreløpig til din e-post. Denne burde sikkert endres til noe annet. Har ikke peiling på hva som er vanlig.

Gi beskjed om noe må endres, har aldri utviklet extension før :)